### PR TITLE
removed gpt-4o typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The application uses a separate model for reasoning tasks (like research analysi
 ### Important Notes
 
 - Only certain OpenAI models (gpt-4o, o1, o3-mini) natively support structured JSON outputs
-- Other models (deepseek-reasoner, gpt-4o) can be used but may require disabling JSON schema validation
+- Other models (deepseek-reasoner) can be used but may require disabling JSON schema validation
 - When using models that don't support JSON schema:
   - Set `BYPASS_JSON_VALIDATION=true` in your .env file
   - This allows non-OpenAI models to be used for reasoning tasks


### PR DESCRIPTION
I noticed that `gpt-4o` was listed as a model that natively supports structured JSON outputs, but then right below it is listed as it does not natively support structured JSON outputs.

I assume this was a typo, so I thought I'd submit a quick PR to prevent confusion if that is the case. Let me know if it should be a different model instead of just removed outright.

Thanks!