### PR TITLE
Continuation of Vercel auto deploy failed #8

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -37,10 +37,6 @@ import {
 import { generateTitleFromUserMessage } from '../../actions';
 import FirecrawlApp from '@mendable/firecrawl-js';
 
-export const maxDuration = process.env.MAX_DURATION
-  ? parseInt(process.env.MAX_DURATION)
-  : 300;
-
 type AllowedTools =
   | 'requestSuggestions'
   | 'deepResearch'
@@ -61,6 +57,10 @@ const app = new FirecrawlApp({
 const reasoningModel = customModel(process.env.REASONING_MODEL || 'o1-mini', true);
 
 export async function POST(request: Request) {
+  const maxDuration = process.env.MAX_DURATION
+    ? parseInt(process.env.MAX_DURATION)
+    : 300; 
+  
   const {
     id,
     messages,


### PR DESCRIPTION
The maxDuration outside was giving this error:

⨯ Next.js can't recognize the exported config field in route "/(chat)/api/chat/route": Unsupported node type "ConditionalExpression" at "maxDuration". Read More - https://nextjs.org/docs/messages/invalid-page-config

Moving it into the POST fixed the issue. (I don´t really know much Javascript, but it seems to be receiving the 60, cause with 300 it wouldn´t work on my computer).

Now it manages to deploy but it still fails when I ask it a question with the following error: Feb 11 19:50:48.22
GET
500
open-deep-research-copy4-ct1py9ikm-neoathenians-projects.vercel.app /api/vote
Failed to get session after creation


P.S. sorry I couldn´t put the variable in the .env earlier.