### PR TITLE
Clarification for noobs (a.k.a. people like me)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ OPENROUTER_API_KEY=****
 # Get your Firecrawl API Key here: https://www.firecrawl.dev/
 FIRECRAWL_API_KEY=****
 
-# Generate a random secret: https://generate-secret.vercel.app/32 or `openssl rand -base64 32`
+# Generate a random secret: https://generate-secret.vercel.app/32 or `openssl rand -base64 32` (after generating it add it to vercel->settings->environment variables)
 AUTH_SECRET=****
 
 # Maximum duration in seconds for serverless functions (Vercel Edge has a lower limit on lower plans)


### PR DESCRIPTION
I managed to get it to run. I was missing both the auth_secret (putting it in the environment variables), and the openrouter_api_key.

It seems the openrouter_api_key is absolutely necessary (without it just doesn´t answer (sends error)). This is kinda misleading because in the README it says:

This repo is compatible with OpenRouter and OpenAI. To use OpenRouter, you need to set the OPENROUTER_API_KEY environment variable.

This makes it sound like you need one or the other (which is what makes sense to me, as I understand it they´re 2 different LLM providers). I was putting only the open_ai_key at the beginning and it was failing, added an open_router and now it works