### PR TITLE
Resolve Issue #51 to correctly set the reasoning model in cookies

### DIFF
--- a/app/(chat)/actions.ts
+++ b/app/(chat)/actions.ts
@@ -2,6 +2,7 @@
 
 import { type CoreUserMessage, generateText } from 'ai';
 import { cookies } from 'next/headers';
+import { models, reasoningModels } from '@/lib/ai/models';
 
 import { customModel } from '@/lib/ai';
 import {
@@ -13,7 +14,12 @@ import { VisibilityType } from '@/components/visibility-selector';
 
 export async function saveModelId(model: string) {
   const cookieStore = await cookies();
-  cookieStore.set('model-id', model);
+  if (models.some((m) => m.id === model)) {
+    cookieStore.set('model-id', model);
+  }
+  if (reasoningModels.some((m) => m.id === model)) {
+    cookieStore.set('reasoning-model-id', model);
+  }
 }
 
 export async function generateTitleFromUserMessage({

--- a/app/(chat)/chat/[id]/page.tsx
+++ b/app/(chat)/chat/[id]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation';
 
 import { auth } from '@/app/(auth)/auth';
 import { Chat } from '@/components/chat';
-import { DEFAULT_MODEL_NAME, models } from '@/lib/ai/models';
+import { DEFAULT_MODEL_NAME, DEFAULT_REASONING_MODEL_NAME, models, reasoningModels } from '@/lib/ai/models';
 import { getChatById, getMessagesByChatId } from '@/lib/db/queries';
 import { convertToUIMessages } from '@/lib/utils';
 import { DataStreamHandler } from '@/components/data-stream-handler';
@@ -41,8 +41,8 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
 
   const reasoningModelIdFromCookie = cookieStore.get('reasoning-model-id')?.value;
   const reasoningModelId =
-    models.find((model) => model.id === reasoningModelIdFromCookie)?.id ||
-    DEFAULT_MODEL_NAME;
+    reasoningModels.find((model) => model.id === reasoningModelIdFromCookie)?.id ||
+    DEFAULT_REASONING_MODEL_NAME;
 
   return (
     <>


### PR DESCRIPTION
Resolved issue #51. Users were unable to set the reasoning model because its ID was not set in the cookies. As a result, the selector set itself to the default reasoning model ID (o1). 

To avoid unnecessary complexity, the `actions.ts` file now sets the reasoning model ID by checking if the model passed in `setModel(...)` matches the array of reasoning models; similarly, there is another conditional to ensure the model passed matches a possible router model, allowing the function to distinguish between router or reasoning model types passed.

I opted not to include a second argument with a default value in `setModel(...)` because that meant refactoring additional files (i.e., `model-selector.tsx`, `chat-header.tsx`). 
 
![image](https://github.com/user-attachments/assets/45a0cf5b-6731-4cbe-b60c-2bffe0c5e377)
